### PR TITLE
Wp amin message

### DIFF
--- a/plugin/wc-asia-demo.php
+++ b/plugin/wc-asia-demo.php
@@ -193,6 +193,13 @@ function wc_asia_demo_register_dashboard_widget() {
 		__( 'WC Asia Greeting', 'wc-asia-demo' ),
 		'wc_asia_demo_render_dashboard_widget'
 	);
+
+	// Force widget to the top of the first (normal) column.
+	global $wp_meta_boxes;
+	$dashboard = $wp_meta_boxes['dashboard']['normal']['core'];
+	$widget    = array( 'wc_asia_demo_greeting_widget' => $dashboard['wc_asia_demo_greeting_widget'] );
+	unset( $dashboard['wc_asia_demo_greeting_widget'] );
+	$wp_meta_boxes['dashboard']['normal']['core'] = array_merge( $widget, $dashboard );
 }
 
 /**


### PR DESCRIPTION
This pull request adds a new retro LED-style greeting widget to the WordPress admin dashboard for the WC Asia Demo plugin. The widget displays a customizable greeting in a visually distinctive style, and includes custom CSS for a scrolling LED effect. The changes also ensure that styles are only loaded on the dashboard page.

Dashboard widget feature:

* Added a new dashboard widget (`wc_asia_demo_greeting_widget`) that displays the greeting set in plugin settings, using a retro LED display style.
* Registered the dashboard widget and enqueued its custom styles by hooking into `wp_dashboard_setup` and `admin_enqueue_scripts` respectively, ensuring styles only load on the dashboard.

Styling enhancements:

* Implemented inline CSS for the widget to create a neon green, scrolling LED text effect, using custom fonts, colors, and animation.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Ffellyph%2Fwc-asia-plugin.git%22%2C%22ref%22%3A%22wp-amin-message%22%2C%22path%22%3A%22plugin%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->